### PR TITLE
Remove trailing comma from the property list of defaultOptions object literal

### DIFF
--- a/src/ssm.js
+++ b/src/ssm.js
@@ -100,7 +100,7 @@
             maxWidth: 999999,
             onEnter: [],
             onLeave: [],
-            onResize: [],
+            onResize: []
         };
 
         //Merge options with defaults


### PR DESCRIPTION
Google Closure Compiler produces a parse error when trailing comma is encountered:

> IE8 (and below) will parse trailing commas in array and object literals incorrectly.
